### PR TITLE
Swap from Colors to Chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Olwiba",
   "license": "GPL-3.0",
   "dependencies": {
+    "chalk": "^1.1.3",
     "colors": "^1.1.2",
     "material-ui": "^0.15.3",
     "react": "^15.2.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "license": "GPL-3.0",
   "dependencies": {
     "chalk": "^1.1.3",
-    "colors": "^1.1.2",
     "material-ui": "^0.15.3",
     "react": "^15.2.1",
     "react-dom": "^15.2.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,5 @@
 const express = require('express')
 const path = require('path')
-const colors = require('colors')
 const chalk = require('chalk')
 
 const gray = chalk.gray

--- a/server/index.js
+++ b/server/index.js
@@ -1,19 +1,25 @@
 const express = require('express')
 const path = require('path')
 const colors = require('colors')
+const chalk = require('chalk')
+
+const gray = chalk.gray
+const yellow = chalk.yellow
+const green = chalk.green
+const cyan = chalk.cyan
 
 const app = express()
 const port = process.env.PORT || 4200
 app.use(express.static(path.join(__dirname, '/../public')))
 
 console.log(
-'********************************************\n'.grey +
-'  Server status: '.yellow + 'Online\n'.green +
-'********************************************\n'.grey +
-'  Reuser is listening on port:'.yellow + port + '\n' +
-'********************************************\n'.grey +
-'  Cleaning the world...\n'.cyan +
-'  One item at a time!\n'.cyan +
-'********************************************'.grey)
+gray('********************************************\n') +
+yellow('  Server status: ') + green('Online\n') +
+gray('********************************************\n') +
+yellow(`  Reuser is listening on port: ${chalk.white(port)} \n`) +
+gray('********************************************\n') +
+cyan('  Cleaning the world...\n') +
+cyan('  One item at a time!\n') +
+gray('********************************************'))
 
 app.listen(port)

--- a/server/index.js
+++ b/server/index.js
@@ -6,12 +6,14 @@ const app = express()
 const port = process.env.PORT || 4200
 app.use(express.static(path.join(__dirname, '/../public')))
 
-console.log('********************************************'.grey)
-console.log('  Server status: '.yellow + 'Online'.green)
-console.log('********************************************'.grey)
-console.log('  Reuser is listening on port: '.yellow + port)
-console.log('********************************************'.grey)
-console.log('  Cleaning the world...'.cyan)
-console.log('  One item at a time!'.cyan)
-console.log('********************************************'.grey)
+console.log(
+'********************************************\n'.grey +
+'  Server status: '.yellow + 'Online\n'.green +
+'********************************************\n'.grey +
+'  Reuser is listening on port:'.yellow + port + '\n' +
+'********************************************\n'.grey +
+'  Cleaning the world...\n'.cyan +
+'  One item at a time!\n'.cyan +
+'********************************************'.grey)
+
 app.listen(port)


### PR DESCRIPTION
Swapped the server start output to use [chalk](https://www.npmjs.com/package/chalk), condensed it into one single console log and swapped the port line to use template literals.

Not really a serious change but it's my code for the day since I haven't done much else 👍
